### PR TITLE
删除excel表格数据中前导及后缀空格

### DIFF
--- a/autopoi/src/main/java/org/jeecgframework/poi/excel/imports/ExcelImportServer.java
+++ b/autopoi/src/main/java/org/jeecgframework/poi/excel/imports/ExcelImportServer.java
@@ -100,6 +100,7 @@ public class ExcelImportServer extends ImportBaseService {
 		boolean isUsed = false;// 是否需要加上这个对象
 		for (int i = row.getFirstCellNum(); i < row.getLastCellNum(); i++) {
 			Cell cell = row.getCell(i);
+			cell = cell == null ? cell : cell.trim();
 			String titleString = (String) titlemap.get(i);
 			if (param.getExcelParams().containsKey(titleString)) {
 				if (param.getExcelParams().get(titleString).getType() == 2) {
@@ -218,6 +219,7 @@ public class ExcelImportServer extends ImportBaseService {
                     }
 					for (int i = firstCellNum, le = lastCellNum; i < le; i++) {
 						Cell cell = row.getCell(i);
+						cell = cell == null ? cell : cell.trim();
 						String titleString = (String) titlemap.get(i);
 						if (excelParams.containsKey(titleString) || Map.class.equals(pojoClass)) {
 							if (excelParams.get(titleString) != null && excelParams.get(titleString).getType() == 2) {


### PR DESCRIPTION
维护大量excel数据时，容易在数据前面和后面加上多余空格，且不易察觉。因此可以在程序中进行 trim() 自动处理。